### PR TITLE
Handling InvalidClientException by resetting the client.

### DIFF
--- a/src/aws-sso.ts
+++ b/src/aws-sso.ts
@@ -63,6 +63,10 @@ export async function refresh() {
         await updateKubeConfig(profiles);
     } catch (err) {
         log.error("[refresh] Error: %s", err);
+        if (err instanceof Error && err.name == "InvalidClientException") {
+            config.delete("ssoClient")
+            log.error("[refresh] Got InvalidClientException error, deleted ssoClient from config");
+        }
         config.set("lastError", `${err}`);
         setNextTokenRefresh();
     } finally {


### PR DESCRIPTION
When the client is invalid[1] but expires in the future, frost will enter loop until the client will expire.
So we reset the client (and in the next trial a new client will be created).

To reproduce:
Edit `ssoClient/clientId` of `/Users/XXX/Library/Application Support/frost/config.json` to some invalid string.

[1] An invalid client may be created for new Frost users, when a wrong configuration is set.