### PR TITLE
Removed the 30minutes subtraction becase AWS doesnt refresh tokens

### DIFF
--- a/src/aws-sso.ts
+++ b/src/aws-sso.ts
@@ -31,7 +31,7 @@ export function setNextTokenRefresh() {
         ? moment(expiresAtConfig, moment.ISO_8601)
         : now;
     const timeoutMs = Math.max(
-        expiresAt.subtract(30, "minutes").diff(now),
+        expiresAt.diff(now),
         500
     );
 


### PR DESCRIPTION
Greetings,
It seems like the SSO API doesn't refresh tokens anymore: `ssooidc.createToken` will return the current expiration when called.
So we need to call `refresh` only after the previous token expired.
(right now, we are calling `refresh` 30 minutes before expiration, and therefore we get expiration less than 30 minutes and keep refreshing.)