### PR TITLE
Switch release flow to draft-then-publish

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,47 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'dependencies'
+
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+
+autolabeler:
+  - label: 'feature'
+    branch:
+      - '/^feat(ure)?[/-].+/'
+  - label: 'fix'
+    branch:
+      - '/^(fix|bug(fix)?)[/-].+/'
+  - label: 'chore'
+    branch:
+      - '/^(chore|deps|dependabot)[/-].+/'
+
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,18 +1,21 @@
-name: 🔍 PR Build
+name: 🔍 Build
 
 # Validates the full release build (all platforms, including macOS signing and
-# notarization) on pull requests, so we can confirm everything works before
-# merging to main. Lints, then delegates the matrix build to build.yaml in
-# "make" mode (signs, notarizes, zips, uploads artifacts; never tags or
-# publishes).
+# notarization) on pull requests and on every push to main, so we can confirm
+# everything works before drafting a release. Lints, then delegates the matrix
+# build to build.yaml in "make" mode (signs, notarizes, zips, uploads
+# artifacts; never tags or publishes).
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
 
 concurrency:
-  group: pr-build-${{ github.ref }}
+  group: build-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,32 @@
+name: 📝 Draft Release Notes
+
+# Maintains a single draft release on GitHub. Each push to main recomputes the
+# draft (version + changelog). Pull request events drive the autolabeler so
+# merged PRs get categorized correctly. Publishing the draft from the GitHub
+# UI is what kicks off release.yaml.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  draft:
+    name: 📝 Update draft release
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📝 Run release-drafter
+        uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,101 +1,36 @@
 name: 🚀 Release Version
 
-on:
-  push:
-    branches:
-      - main
+# Fires when a draft release is published from the GitHub UI. The draft is
+# maintained by release-drafter.yaml; ci.yaml validates each push to main
+# before we get here. This workflow just rebuilds the matrix in publish mode
+# and uploads signed/notarized distributables to the already-published
+# release.
 
-env:
-  NODEJS_VERSION: 22
+on:
+  release:
+    types:
+      - published
 
 jobs:
-  test:
-    name: 🧹 Lint app
+  prep:
+    name: 🔖 Resolve release version
     runs-on: ubuntu-latest
-    steps:
-      - name: 📥 Checkout sources
-        uses: actions/checkout@v6
-
-      - name: ⚙️ Install Node.js and NPM
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODEJS_VERSION }}
-          cache: npm
-
-      - name: 📦 Install node modules
-        run: |
-          npm ci
-
-      - name: 🔨 Build app
-        run: |
-          npm run build
-
-      - name: 🧹 Run eslint
-        run: |
-          npm run lint
-
-  tag:
-    name: 🏷 Create a tag
-    runs-on: ubuntu-latest
-    needs:
-      - test
-    steps:
-      - name: 📥 Checkout sources
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: "0"
-
-      - id: tag-without-v
-        name: 🔖 Get version without v
-        uses: anothrNick/github-tag-action@1.75.0
-        env:
-          WITH_V: false
-          DRY_RUN: true
-          DEFAULT_BUMP: patch
-          RELEASE_BRANCHES: main
-
-      - id: tag-with-v
-        name: 🏷 Bump version and push tag
-        uses: anothrNick/github-tag-action@1.75.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WITH_V: true
-          DEFAULT_BUMP: patch
-          RELEASE_BRANCHES: main
-
     outputs:
-      tag: ${{ steps.tag-with-v.outputs.new_tag }}
-      tag_without_v: ${{ steps.tag-without-v.outputs.new_tag }}
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - id: v
+        name: 🔖 Strip leading v from tag
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
   release-app:
     name: 📦 Release App
     needs:
-      - tag
+      - prep
     uses: ./.github/workflows/build.yaml
     secrets: inherit
     with:
       publish: true
-      version: ${{ needs.tag.outputs.tag_without_v }}
-
-  publish:
-    name: 📢 Publish Release
-    needs:
-      - tag
-      - release-app
-    runs-on: ubuntu-latest
-    steps:
-      - name: 📢 Publish release
-        run: |
-          release_url=$(
-            curl --fail \
-              -H "Accept: application/vnd.github.v3+json" \
-              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-              "https://api.github.com/repos/${{ github.repository }}/releases" |
-              jq -r '.[] | select(.tag_name == "${{ needs.tag.outputs.tag }}") | .url'
-          )
-          curl --fail \
-            -X PATCH \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "${release_url}" \
-            -d '{"draft":false}'
+      version: ${{ needs.prep.outputs.version }}


### PR DESCRIPTION
## Summary
- Adds `release-drafter` to maintain a single draft release on every push to `main` (and autolabel PRs by branch prefix).
- Reworks `release.yaml` to trigger on `release: published` — publishing the draft from the GitHub UI is now what kicks off the matrix build and uploads signed/notarized artifacts to the already-published release.
- Extends `ci.yaml` to also run on `push: main`, so the build matrix validates every merge before the draft moves.

## Why
The previous `release.yaml` auto-tagged every push to `main`, built, ran `electron-forge publish`, then PATCHed the resulting draft to undraft it. The most recent run failed because the publisher created the draft using the original `package.json` version (`0.0.1`) rather than the bumped tag, so the post-build PATCH for `v0.2.15` got an empty URL and `curl` aborted. Manual gating via the GitHub UI removes the brittle multi-step coordination.

## New flow
1. PR opened → `ci.yaml` validates, `release-drafter` autolabels.
2. PR merged → `ci.yaml` re-runs on `main`, `release-drafter` updates the draft to the next `v$RESOLVED_VERSION` (default patch; `major`/`minor`/`patch` labels override).
3. You click **Publish release** in the GitHub UI.
4. `release.yaml` fires on `release: published`, runs the matrix build with `publish: true`, and uploads `.zip`s to the now-published release.

## Test plan
- [ ] Merge this PR and confirm `ci.yaml` runs on `main`.
- [ ] Confirm `release-drafter` creates a `v0.2.15` draft with this PR listed under 🧰 Maintenance.
- [ ] Publish the draft and confirm `release.yaml` fires, the matrix completes, and signed `.zip`s appear on the published release.
- [ ] Confirm no stray draft releases are left behind.