### PR TITLE
Fix doodle circle sizing on the region step and pill clipping in evolution

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -205,7 +205,7 @@ sso_role_name  = AdministratorAccess
 sso_session    = frost
 sso_account_id = 123456789012
 sso_role_name  = PowerUserAccess
-<span class="circled"><span class="c-key">region</span>         = <span class="c-val">eu-west-1</span><svg class="doodle-circle" viewBox="0 0 120 50" preserveAspectRatio="none" aria-hidden="true"><path d="M60,7 C30,5 8,14 6,26 C7,40 30,47 60,47 C92,45 117,38 113,22 C108,9 80,4 56,8 C50,8 47,11 47,11" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg></span></code></pre>
+<span class="circled"><span class="c-key">region</span>         = <span class="c-val">eu-west-1</span><svg class="doodle-circle" viewBox="0 0 120 50" preserveAspectRatio="none" aria-hidden="true" style="top: -70%; left: -18%; width: 136%; height: 240%;"><path d="M60,7 C30,5 8,14 6,26 C7,40 30,47 60,47 C92,45 117,38 113,22 C108,9 80,4 56,8 C50,8 47,11 47,11" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg></span></code></pre>
       </div>
 
       <div class="evolution">

--- a/docs/style.css
+++ b/docs/style.css
@@ -782,8 +782,7 @@ main {
   font-size: 0.95rem;
   background: transparent;
   border: none;
-  padding: 0;
-  overflow-x: auto;
+  padding: 0.25rem 0;
   white-space: nowrap;
   color: var(--text-faint);
   letter-spacing: 0.02em;


### PR DESCRIPTION
Step 3's hand-drawn circle was crossing through the AWS-orange "region" key, making the arc invisible where they overlapped. Bumped its inline SVG dimensions (top/left/width/height) so the ellipse sits well above, below, and to the left of the text.

The "Bring it together" evolution rows were cropping the colored mini pills at the top because the surrounding code element had overflow-x: auto, which implicitly clips on the y-axis too. Switched to padding-block instead so the pills have vertical breathing room and nothing gets clipped.