### PR TITLE
Trigger release workflow on tag push

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -28,5 +28,9 @@ jobs:
         uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
+          # On PR events we only want the autolabeler to run. Without this,
+          # the releaser tries to update the draft with target_commitish set
+          # to refs/pull/N/merge (not a real branch) and GitHub rejects it.
+          disable-releaser: ${{ github.event_name == 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,15 +1,22 @@
 name: 🚀 Release Version
 
-# Fires when a draft release is published from the GitHub UI. The draft is
-# maintained by release-drafter.yaml; ci.yaml validates each push to main
-# before we get here. This workflow just rebuilds the matrix in publish mode
-# and uploads signed/notarized distributables to the already-published
-# release.
+# Fires when a vX.Y.Z tag is pushed. release-drafter maintains a draft
+# release on each push to main; publishing that draft from the UI creates
+# the tag (attributed to the human who clicked Publish, which is what makes
+# this workflow run). We avoid `on: release: published` because the draft
+# is owned by github-actions[bot] and bot-attributed release events don't
+# fire downstream workflows. workflow_dispatch is kept as a manual fallback.
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to (re)build, e.g. v0.2.15"
+        required: true
+        type: string
 
 jobs:
   prep:
@@ -21,7 +28,7 @@ jobs:
       - id: v
         name: 🔖 Strip leading v from tag
         env:
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

- Switch `release.yaml` trigger from `on: release: published` to `on: push: tags: ["v*"]` so publishing a draft from the UI actually runs the workflow. Adds `workflow_dispatch` with a `tag` input as a manual fallback for the v0.2.15 backfill or any future emergency.
- Tighten two visual issues on the docs site: the hand-drawn circle around `region = eu-west-1` no longer crosses through the AWS-orange `region` text, and the colored pills in the "Bring it together" rows are no longer clipped at the top (was caused by `overflow-x: auto` on `.evo-name` implicitly clipping the y-axis too).

## Why the release trigger change

Zero `release` event workflow runs have ever existed on this repo, and v0.2.15 was published but nothing built. The likely cause: release-drafter owns the draft as `github-actions[bot]`, and the `release.published` event for a bot-owned draft is suppressed (one of the cases GitHub avoids to prevent loops).

When the user publishes the draft, GitHub creates the tag at HEAD of the target branch, and that tag push is attributed to the human who clicked Publish — so `on: push: tags` fires workflows normally. The version is read from `github.ref_name` (the tag) instead of `github.event.release.tag_name`.

## How to backfill v0.2.15

Once merged: Actions → 🚀 Release Version → Run workflow → enter `v0.2.15`. The build matrix runs in publish mode and uploads signed/notarized artifacts to the existing release.

## Test plan

- [ ] Merge to main.
- [ ] Trigger the workflow manually for `v0.2.15` and confirm artifacts appear on the release.
- [ ] On the next push to main + UI-publish, verify the workflow fires automatically without dispatch.
- [ ] Spot-check the docs site: step 3 circle clears the word "region", and the first two rows of "Bring it together" show full pills with rounded tops.